### PR TITLE
Make it compatible with `-preview=in`

### DIFF
--- a/source/semver.d
+++ b/source/semver.d
@@ -214,7 +214,7 @@ struct SemVer
     }
 
     /// ditto
-    int opCmp(in SemVer other) const
+    int opCmp(const SemVer other) const
     {
         return this.opCmp(other);
     }
@@ -231,7 +231,7 @@ struct SemVer
     }
 
     /// ditto
-    bool opEquals(in SemVer other) const
+    bool opEquals(const SemVer other) const
     {
         return this.opEquals(other);
     }
@@ -262,7 +262,7 @@ struct SemVer
     }
 
     /// ditto
-    VersionPart differAt(in SemVer other) const
+    VersionPart differAt(const SemVer other) const
     {
         return this.differAt(other);
     }


### PR DESCRIPTION
```
Having an 'in' and a 'const ref' overload conflicts.
Only expose a 'const' and a 'const ref' overload so that users can use '-preview=in'.
```

Note that your use case is exactly why `-preview=in` was built.