### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Compiled Object files
+*.o
+*.obj
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.a
+*.lib
+
+# Executables
+*.exe
+
+# DUB
+.dub
+docs.json
+__dummy.html
+docs/
+
+# DUB testing artifacts
+*-test-library
+*-test-application
+
+# Code coverage
+*.lst
+
+# Emacs
+*~
+
+# Visual Studio Code
+.vscode


### PR DESCRIPTION
We use git submodules for dependency management,
which means that the submodule gets '-dirty' as soon
as we build.