### PR TITLE
feature/query semver components

### DIFF
--- a/source/semver.d
+++ b/source/semver.d
@@ -159,6 +159,47 @@ struct SemVer
     }
 
     /**
+     * Query a Major, Minor and Patch as integers
+     */
+    int query(VersionPart versionPart) const
+    in
+    {
+        assert(this.isValid);
+    }
+    do
+    {
+        import std.conv : to;
+        import std.exception : enforce;
+        int result;
+        switch (versionPart)
+        {
+        case VersionPart.MAJOR:
+            result = ids[0];
+            break;
+        case VersionPart.MINOR:
+            result = ids[1];
+            break;
+        case VersionPart.PATCH:
+            result = ids[2];
+            break;
+        default:
+            enforce(false, "Can't query " ~ versionPart.to!string ~ " as an integer.");
+            break;
+        }
+        return result;
+    }
+
+    unittest
+    {
+        import std.exception : assertThrown;
+        assert(SemVer("1.2.3").query(VersionPart.MAJOR) == 1);
+        assert(SemVer("1.2.3").query(VersionPart.MINOR) == 2);
+        assert(SemVer("1.2.3").query(VersionPart.PATCH) == 3);
+        assertThrown(SemVer("1.2.3-alpha").query(VersionPart.BUILD));
+        assertThrown(SemVer("1.2.3-alpha+build").query(VersionPart.PRERELEASE));
+    }
+
+    /**
      * Compare this $(D_PSYMBOL SemVer) with the $(D_PARAM other) $(D_PSYMBOL SemVer).
      *
      * Note that the build parts are considered for this operation.

--- a/source/semver.d
+++ b/source/semver.d
@@ -200,6 +200,53 @@ struct SemVer
     }
 
     /**
+     * Query a possibly decoded PRERELEASE and BUILD string
+     */
+    string queryAsString(VersionPart versionPart) const
+    in
+    {
+        assert(this.isValid);
+    }
+    do
+    {
+        import std.conv : to;
+        import std.exception : enforce;
+        string result;
+        switch (versionPart)
+        {
+        case VersionPart.MAJOR:
+            result = ids[0].to!string;
+            break;
+        case VersionPart.MINOR:
+            result = ids[1].to!string;
+            break;
+        case VersionPart.PATCH:
+            result = ids[2].to!string;
+            break;
+        case VersionPart.PRERELEASE:
+            result = prerelease.join(".");
+            break;
+        case VersionPart.BUILD:
+            result = build.join(".");
+            break;
+        default:
+            enforce(false, "Can't query unknown " ~ versionPart.to!string ~ " as a string.");
+            break;
+        }
+        return result;
+    }
+
+    unittest
+    {
+        import std.exception : assertThrown;
+        assert(SemVer("1.2.3").queryAsString(VersionPart.MAJOR) == "1");
+        assert(SemVer("1.2.3").queryAsString(VersionPart.MINOR) == "2");
+        assert(SemVer("1.2.3").queryAsString(VersionPart.PATCH) == "3");
+        assert(SemVer("1.2.3-alpha-beta.2+build-seq.3").queryAsString(VersionPart.PRERELEASE) == "alpha-beta.2");
+        assert(SemVer("1.2.3-alpha-beta.2+build-seq.3").queryAsString(VersionPart.BUILD) == "build-seq.3");
+    }
+
+    /**
      * Compare this $(D_PSYMBOL SemVer) with the $(D_PARAM other) $(D_PSYMBOL SemVer).
      *
      * Note that the build parts are considered for this operation.


### PR DESCRIPTION
Parsing a SemVer number is fine, but sometime it might be helpful to access the decoded data. So two query functions were
added:

int this.query(VersionPart vp) 
string this.queryAsStrings(VersionPart vp) 

These easily allow to query the decoded data.