### PR TITLE
Removed scope guards where compiler rightgully emits warnings

### DIFF
--- a/source/semver.d
+++ b/source/semver.d
@@ -132,7 +132,7 @@ struct SemVer
     /**
      * Return the canonical string format.
      */
-    string toString() const scope @safe
+    string toString() const @safe
     {
         import std.string : format;
 
@@ -185,7 +185,7 @@ struct SemVer
         return result;
     }
 
-    private SemVer appendPrerelease0() scope @safe pure nothrow
+    private SemVer appendPrerelease0() @safe pure nothrow
     {
         if (prerelease.empty)
             prerelease ~= "0";
@@ -311,7 +311,7 @@ struct SemVer
                 return ids[i] < other.ids[i] ? -1 : 1;
         }
 
-        int compareSufix(const string[] suffix, const string[] anotherSuffix) @safe pure
+        int compareSufix(const scope string[] suffix, const string[] anotherSuffix) @safe pure
         {
             import std.conv : to;
             import std.string : isNumeric;
@@ -372,11 +372,8 @@ struct SemVer
     /**
      * Compare two $(B different) versions and return the parte they differ on.
      */
-    VersionPart differAt(ref const SemVer other) const scope @safe pure nothrow
-    in
-    {
-        assert(this != other);
-    }
+    VersionPart differAt(ref const SemVer other) const scope @safe pure
+    in (this != other)
     do
     {
         foreach (i; VersionPart.MAJOR .. VersionPart.PRERELEASE)
@@ -395,7 +392,7 @@ struct SemVer
     }
 
     /// ditto
-    VersionPart differAt(const SemVer other) const scope @safe pure nothrow
+    VersionPart differAt(const SemVer other) const scope @safe pure
     {
         return this.differAt(other);
     }


### PR DESCRIPTION
I tested the package with the latest DMD build. It emits some warnings on scope guard and a nothrow attributes. 

Fixed up the code, so that is compiling properly.