### PR TITLE
Added methods .major, .minor, .patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ auto version2 = SemVer("1.0.0-rc.1");
 assert(version2.isValid);
 assert(!version2.isStable);
 
+auto version3 = Semver("1.2.3-rc.42");
+assert(version3.major == 1);
+assert(version3.minor == 2);
+assert(version3.patch == 3);
+
 assert(SemVer("1.0.0") > SemVer("1.0.0+build.1"));
 assert(SemVer("1.0.0").differAt(SemVer("1.0.0+build.1")) == VersionPart.BUILD);
 

--- a/source/semver.d
+++ b/source/semver.d
@@ -130,6 +130,60 @@ struct SemVer
     }
 
     /**
+     * Return major part of the version
+     */
+    auto major() const scope @safe pure nothrow @nogc
+    in
+    {
+        assert(this.isValid);
+    }
+    do {
+        return this.ids[VersionPart.MAJOR];
+    }
+
+    /**
+     * Return minor part of the version
+     */
+    auto minor() const scope @safe pure nothrow @nogc
+    in
+    {
+        assert(this.isValid);
+    }
+    do {
+        return this.ids[VersionPart.MINOR];
+    }
+
+    /**
+     * Return patch part of the version
+     */
+    auto patch() const scope @safe pure nothrow @nogc
+    in
+    {
+        assert(this.isValid);
+    }
+    do {
+        return this.ids[VersionPart.PATCH];
+    }
+
+    @safe unittest
+    {
+        const auto v = SemVer("1.2.3-alpha");
+        assert(v.major == 1);
+        assert(v.minor == 2);
+        assert(v.patch == 3);
+
+        const auto v2 = SemVer("2");
+        assert(v2.major == 2);
+        assert(v2.minor == 0);
+        assert(v2.patch == 0);
+
+        const auto v3 = SemVer("0.2");
+        assert(v3.major == 0);
+        assert(v3.minor == 2);
+        assert(v3.patch == 0);
+    }
+
+    /**
      * Return the canonical string format.
      */
     string toString() const scope @safe


### PR DESCRIPTION
These methods are needed to simplify access to version parts.

For example, presence of these methods could significantly improve readability of following [code](df22b63c37d929f052ef2db6cbb19dfba7d39b16):

```D
immutable auto url_get_pip_py = build_version < SemVer(3, 7) ?
    "https://bootstrap.pypa.io/pip/%s.%s/get-pip.py".format(build_version.query(VersionPart.MAJOR), build_version.query(VersionPart.MINOR)) :
    "https://bootstrap.pypa.io/pip/get-pip.py";
```